### PR TITLE
Update SZP08_modelovani_a_projekce.ad

### DIFF
--- a/szmgr/SZP08_modelovani_a_projekce.ad
+++ b/szmgr/SZP08_modelovani_a_projekce.ad
@@ -292,7 +292,7 @@ Výsledná matice je:
 
 [stem]
 ++++
-P_\text{persp} =  M_\text{depth} \cdot S \cdot D \cdot T =
+P_\text{persp} =  S \cdot D \cdot M_\text{depth} \cdot T =
 
 \begin{bmatrix}
     \textcolor{green}{\frac{2 \cdot \text{near}}{\text{right} - \text{left}}}


### PR DESCRIPTION
Nejdříve se musí provést depth mapping a až teprve můžeme provést perspective division. Je to napsáno i v citaci: http://learnwebgl.brown37.net/08_projections/projections_perspective.html


    Translate the apex of the frustum to the origin. (Yellow matrix)
    Scale the depth values (z) into a normalized range (-1,+1) (and setup for division by (-z)). (Purple matrix)
    Perform the perspective calculation. (Gray matrix)
    Scale the 2D (x’,y’) values in the viewing window to a 2-by-2 unit square; (-1,-1) to (+1,+1). (Cyan matrix)